### PR TITLE
Remove coverage badge generation from CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,10 +47,7 @@ jobs:
       - name: Test with pytest
         run: |
           just test ${{ (github.ref == 'refs/heads/main' && matrix.os == 'ubuntu-latest')
-            && '--cov=hsl_kaupunkipyora_exporter --cov-report=html --cov-report=xml' || '' }}
-      - name: Generate coverage badge
-        if: github.ref == 'refs/heads/main' && matrix.os == 'ubuntu-latest'
-        run: uv run --group dev --group github genbadge coverage -i coverage.xml -o htmlcov/coverage.svg
+            && '--cov=hsl_kaupunkipyora_exporter --cov-report=html' || '' }}
       - name: Upload coverage report
         if: github.ref == 'refs/heads/main' && matrix.os == 'ubuntu-latest'
         # v7


### PR DESCRIPTION
Removed the coverage badge generation step and the associated XML report from the CI workflow.

- Deleted the "Generate coverage badge" step in `.github/workflows/test.yml`.
- Removed `--cov-report=xml` from the pytest command as it is no longer needed.
- Preserved HTML coverage reports and artifact uploads.