### PR TITLE
Add CODE_OF_CONDUCT, SECURITY, and CONTRIBUTING governance docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,86 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We pledge to make our community welcoming, safe, and equitable for all. We are committed to fostering an environment
+that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics
+including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender,
+gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin,
+socio-economic position, level of education, or other status. The same privileges of participation are extended to
+everyone who participates in good faith and in accordance with this Covenant.
+
+## Encouraged Behaviors
+
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive
+behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture,
+background, or native language. With these considerations in mind, we agree to behave mindfully toward each other and
+act in ways that center our shared values, including:
+
+- Respecting the purpose of our community, our activities, and our ways of gathering.
+- Engaging kindly and honestly with others.
+- Respecting different viewpoints and experiences.
+- Taking responsibility for our actions and contributions.
+- Gracefully giving and accepting constructive feedback.
+- Committing to repairing harm when it occurs.
+- Behaving in other ways that promote and sustain the well-being of our community.
+
+## Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are
+violations of this Code of Conduct.
+
+- **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any
+  clear request to stop.
+- **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a community member or group of
+  people.
+- **Stereotyping or discrimination.** Characterizing anyone's personality or behavior on the basis of immutable
+  identities or traits.
+- **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate in the context or
+  purpose of the community.
+- **Violating confidentiality.** Sharing or acting on someone's personal or private information without their
+  permission.
+- **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person or group.
+- **Behaving in other ways that threaten the well-being of our community.**
+
+### Other Restrictions
+
+- **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone else to evade
+  enforcement actions.
+- **Failing to credit sources.** Not properly crediting the sources of content you contribute.
+- **Promotional materials.** Sharing marketing or other commercial content in a way that is outside the norms of the
+  community.
+- **Irresponsible communication.** Failing to responsibly present content which includes, links, or describes any other
+  restricted behaviors.
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict
+represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help
+avoid conflicts and minimize harm. When an incident does occur, it is important to report it promptly.
+
+To report a possible violation, please contact <nikomsavola@gmail.com>. Community Moderators take reports of violations
+seriously and will make every effort to respond in a timely manner.
+
+## Addressing and Repairing Harm
+
+In order to honor these values, enforcement actions are carried out in private with the involved parties, but
+communicating to the whole community may be part of a mutually agreed upon resolution.
+
+If an investigation by the Community Moderators finds that this Code of Conduct has been violated, they may take any
+action they deem appropriate, up to and including a temporary or permanent ban from the community.
+
+Our goal is to address and repair harm, and to find ways to safely reintegrate someone back into the community after an
+incident occurs. This may include:
+
+- A private conversation to discuss the behavior and its impact.
+- A public or private apology.
+- A temporary or permanent ban from certain community spaces or activities.
+- A temporary or permanent ban from the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 3.0, permanently available at
+<https://www.contributor-covenant.org/version/3/0/>.
+
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under CC BY-SA 4.0. To view a copy
+of this license, visit <https://creativecommons.org/licenses/by-sa/4.0/>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing
+
+Inside the project directory, you may run the following commands.
+
+## Development Setup
+
+```bash
+just install
+```
+
+## Running tests
+
+```bash
+just test
+```
+
+## Running linting & formatting (pre-commit)
+
+```bash
+just pre-commit
+```
+
+## AI Usage Policy
+
+The use of AI tools to accelerate your development workflow, whether for prototyping, writing tests, or improving
+documentation, is **encouraged**.
+
+However, as a contributor, you remain **fully responsible** for the code and content you submit. Please ensure the
+following:
+
+1. **No "AI Slop"**: Do not submit unreviewed, low-quality, or redundant AI-generated content.
+1. **Verify & Test**: All AI-generated code must be reviewed, tested, and verified to work as intended.
+1. **Maintainability**: The content must be clear, idiomatic, and maintainable by a human.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+I take the security of this project seriously. If you believe you have found a security vulnerability, please report it
+to me responsibly.
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, please use the
+[GitHub Private Vulnerability Reporting](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository)
+feature through [Security Advisories](https://github.com/nikosavola/hsl-kaupunkipyora-exporter/security/advisories), or
+contact @nikosavola directly.
+
+### What to include in a report
+
+To help me understand and fix the issue, please include as much information as possible:
+
+- A description of the vulnerability and its potential impact.
+- Steps to reproduce the issue (a minimal working example is highly appreciated).
+- Any potential mitigations you've identified.
+
+### Process
+
+```mermaid
+graph TD
+    A[Vulnerability Report Received] --> B[Acknowledge Receipt]
+    B --> C[Investigate & Confirm]
+    C --> D[Develop & Test Fix]
+    D --> E[Release New Version]
+    E --> F[Credit Reporter in Release Notes]
+```


### PR DESCRIPTION
Adapted from nikosavola/sphinxcontrib-bibtex-urn; updated SECURITY.md
advisory URL and CONTRIBUTING.md commands to match this repo.

https://claude.ai/code/session_01HCFN7PjfC7qfWjWSBhFt9g