### PR TITLE
Add Finnish and Swedish README translations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     hooks:
       - id: codespell
         priority: 10
-        exclude: ^(uv\.lock|tests/test_data/|gpx_output/|tcx_output/)
+        exclude: ^(uv\.lock|tests/test_data/|gpx_output/|tcx_output/|README\.sv\.md)
         additional_dependencies:
           - tomli
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/README.fi.md
+++ b/README.fi.md
@@ -4,12 +4,11 @@
 [![fi](https://img.shields.io/badge/lang-fi-blue.svg)](./README.fi.md)
 [![sv](https://img.shields.io/badge/lang-sv-yellow.svg)](./README.sv.md)
 
-Jäsennä [HSL:n kaupunkipyörien](https://www.hsl.fi/omat-tiedot/kaupunkipyorat/ajohistoria) ajohistoriasi ja vie jokainen
-ajo Strava-yhteensopivana TCX- tai GPX-tiedostona.
+Muuta [HSL:n kaupunkipyörien](https://www.hsl.fi/omat-tiedot/kaupunkipyorat/matkahistoria) ajohistoriasi Strava-yhteensopiviksi TCX- tai GPX-tiedostoiksi.
 
 ## Asennus
 
-Vaatii Python 3.13+. Helpoin tapa ajaa työkalu on [`uvx`](https://docs.astral.sh/uv/):llä:
+Vaaditaan Python 3.13+. Helpoin tapa ajaa työkalu on [`uvx`](https://docs.astral.sh/uv/):llä:
 
 ```bash
 uvx hsl-kaupunkipyora-exporter rides.txt
@@ -24,34 +23,34 @@ hsl-kaupunkipyora-exporter rides.txt
 
 ## Käyttö
 
-1. Avaa ajohistoriasi osoitteessa <https://www.hsl.fi/omat-tiedot/kaupunkipyorat/ajohistoria>.
-1. Tallenna sivu HTML-tiedostona (`Ctrl+S`) **tai** kopioi näkyvä teksti `.txt`-tiedostoon.
-1. Aja exporter:
+1. Avaa ajohistoriasi osoitteessa <https://www.hsl.fi/omat-tiedot/kaupunkipyorat/matkahistoria>.
+1. Tallenna sivu HTML-tiedostona (`Ctrl+S`) **tai** kopioi ajohistorian osuus `.txt`-tekstitiedostoon.
+1. Aja työkalu:
 
 ```bash
 uvx hsl-kaupunkipyora-exporter rides.html
 ```
 
-### Reittitilat
+### Reititystavat
 
-Exporter tukee kolmea eri tilaa maantieteellisen datan käsittelyyn:
+HSL Kaupunkipyörä Exporter tukee kolmea eri tapaa reitittää paikkatiedot:
 
-1. **Vain yhteenveto (oletus)**: Vie TCX-tiedoston, joka sisältää HSL:n ilmoittaman tarkan matkan ja keston, mutta ei
+1. **Vain yhteenveto (oletus)**: Tuottaa TCX-tiedoston, joka sisältää HSL:n ilmoittaman matkan ja keston, mutta ei
    GPS-reittipisteitä. Tämä on tarkin tapa kirjata kilometrit Stravaan ilman reitin arvaamista.
-1. **Suora reitti (`--linear`)**: Sisältää yksinkertaisen kahden pisteen suoran viivan lähtö- ja palautusaseman välillä.
-   Hyödyllinen, jos haluat perusvisualisoinnin kartalle.
+1. **Suora reitti (`--linear`)**: Tuottaa suoran viivan lähtö- ja palautusaseman välillä.
+   Hyödyllinen, jos haluat yksinkertaisen visualisoinnin kartalle.
 1. **Reititetty polku (`--use-route`)**: Hakee ehdotetun pyöräilyreitin
-   [Digitransit-rajapinnasta](https://digitransit.fi/kehittajille/rajapinnat/). Tämä tarjoaa realistisen reitin kartalla
-   ja säilyttää HSL:n matkatiedot (TCX:ää käytettäessä). Vaatii
-   [ilmaisen API-avaimen](https://digitransit.fi/kehittajille/api-rekisteroityminen/).
+   [Digitransit-rajapinnasta](https://digitransit.fi/en/developers/apis/). Tämä tarjoaa realistisen reitin kartalla
+   sekä säilyttää HSL:n antaman matkan ja keston (TCX:ää käytettäessä). Vaatii
+   [ilmaisen API-avaimen](https://digitransit.fi/en/developers/api-registration/).
 
 ### Valinnat
 
 | Lippu                | Kuvaus                                                                 |
 | -------------------- | ---------------------------------------------------------------------- |
 | `--output-dir DIR`   | Hakemisto, johon tiedostot kirjoitetaan (oletus: `./tcx_output`)       |
-| `--format FMT`       | Vientimuoto: `tcx` (oletus) tai `gpx`.                                 |
-| `--linear`           | Sisällytä suora viiva asemien välillä                                  |
+| `--format FMT`       | Tiedostomuoto: `tcx` (oletus) tai `gpx`.                                 |
+| `--linear`           | Käytä suoraa viivaa asemien välillä                                    |
 | `--use-route`        | Käytä HSL:n ehdottamaa pyöräilyreittiä suoran viivan sijaan            |
 | `--api-key KEY`      | Digitransit API -avain (vaihtoehto `DIGITRANSIT_API_KEY`-ympäristömuuttujalle) |
 | `--refresh-stations` | Pakota pyöräasemien koordinaattilistan uudelleenlataus                 |
@@ -59,26 +58,25 @@ Exporter tukee kolmea eri tilaa maantieteellisen datan käsittelyyn:
 
 ### TCX vs GPX
 
-Vaikka GPX on yleisin muoto, se ei tue eksplisiittistä "kokonaismatkan" ohitusta. Strava laskee matkan annettujen
+Vaikka GPX on yleisin tiedostomuoto, se ei tue ajetun kokonaismatkan antamista. Strava laskee matkan annettujen
 GPS-pisteiden perusteella.
 
-**TCX** on oletus- ja suositeltu muoto, koska sen avulla työkalu voi kertoa Stravalle tarkalleen, kuinka monta
-kilometriä ajo oli, GPS-reitistä riippumatta.
+**TCX** on suositellumpi tiedostomuoto, koska sen avulla kaupunkipyörän antama etäisyyslukema pysyy tiedostossa GPS-reitistä riippumatta.
 
 ```bash
-# Vie TCX-muotoon suoralla viivalla asemien välillä
-uvx hsl-kaupunkipyora-exporter rides.txt --linear
+# Tuota TCX-tiedosto suoralla viivalla asemien välillä
+uvx hsl-kaupunkipyora-exporter rides.txt --format tcx --linear
 ```
 
 ### Reititetyn polun asetus
 
 Käyttääksesi HSL:n ehdottamaa todellista pyöräilyreittiä tarvitset Digitransit API -avaimen:
 
-1. Rekisteröidy ilmaiseksi osoitteessa [Digitransit Developer Portal](https://digitransit.fi/kehittajille/api-rekisteroityminen/).
+1. Rekisteröidy ilmaiseksi osoitteessa [Digitransit Developer Portal](https://digitransit.fi/en/developers/api-registration/).
 1. Anna avain `--api-key`-lipulla tai `DIGITRANSIT_API_KEY`-ympäristömuuttujalla.
 
 ```bash
-uvx hsl-kaupunkipyora-exporter rides.txt --use-route --api-key avaimesi_tahan
+uvx hsl-kaupunkipyora-exporter rides.txt --use-route --api-key AVAIMESI_TÄHÄN
 ```
 
 ### Kilometrikisa
@@ -86,13 +84,13 @@ uvx hsl-kaupunkipyora-exporter rides.txt --use-route --api-key avaimesi_tahan
 Tämä on kätevä tapa lisätä **Alepa Fillari** -kilometrit [Kilometrikisaan](https://www.kilometrikisa.fi/) tuomalla ajot
 ensin Stravaan.
 
-## Miten se toimii
+## Arkkitehtuuri
 
 ```mermaid
 graph TD
     A[HSL:n ajohistoria<br/>HTML tai teksti] --> B(RideHistoryParser)
     B --> C{StationLookup}
-    C -- Koordinaatit löytyivät --> D{Reittitila?}
+    C -- Koordinaatit löytyivät --> D{Reititystapa?}
     C -- Ei löydy --> E[Ohita ajo]
 
     D -- Oletus --> F[Vain yhteenveto]
@@ -106,9 +104,9 @@ graph TD
     I --> J[Strava-yhteensopivat<br/>TCX- tai GPX-tiedostot]
 ```
 
-## Kehitys
+## Kehittäminen
 
-Käytä [`just`](https://github.com/casey/just)-työkalua tehtävien ajamiseen.
+Käytä [`just`](https://github.com/casey/just)-työkalua komentojen suorittamiseen.
 
 ```bash
 git clone https://github.com/nikosavola/hsl-kaupunkipyora-exporter.git

--- a/README.fi.md
+++ b/README.fi.md
@@ -4,7 +4,8 @@
 [![fi](https://img.shields.io/badge/lang-fi-blue.svg)](./README.fi.md)
 [![sv](https://img.shields.io/badge/lang-sv-yellow.svg)](./README.sv.md)
 
-Muuta [HSL:n kaupunkipyörien](https://www.hsl.fi/omat-tiedot/kaupunkipyorat/matkahistoria) ajohistoriasi Strava-yhteensopiviksi TCX- tai GPX-tiedostoiksi.
+Muuta [HSL:n kaupunkipyörien](https://www.hsl.fi/omat-tiedot/kaupunkipyorat/matkahistoria) ajohistoriasi
+Strava-yhteensopiviksi TCX- tai GPX-tiedostoiksi.
 
 ## Asennus
 
@@ -37,31 +38,32 @@ HSL Kaupunkipyörä Exporter tukee kolmea eri tapaa reitittää paikkatiedot:
 
 1. **Vain yhteenveto (oletus)**: Tuottaa TCX-tiedoston, joka sisältää HSL:n ilmoittaman matkan ja keston, mutta ei
    GPS-reittipisteitä. Tämä on tarkin tapa kirjata kilometrit Stravaan ilman reitin arvaamista.
-1. **Suora reitti (`--linear`)**: Tuottaa suoran viivan lähtö- ja palautusaseman välillä.
-   Hyödyllinen, jos haluat yksinkertaisen visualisoinnin kartalle.
+1. **Suora reitti (`--linear`)**: Tuottaa suoran viivan lähtö- ja palautusaseman välillä. Hyödyllinen, jos haluat
+   yksinkertaisen visualisoinnin kartalle.
 1. **Reititetty polku (`--use-route`)**: Hakee ehdotetun pyöräilyreitin
-   [Digitransit-rajapinnasta](https://digitransit.fi/en/developers/apis/). Tämä tarjoaa realistisen reitin kartalla
-   sekä säilyttää HSL:n antaman matkan ja keston (TCX:ää käytettäessä). Vaatii
+   [Digitransit-rajapinnasta](https://digitransit.fi/en/developers/apis/). Tämä tarjoaa realistisen reitin kartalla sekä
+   säilyttää HSL:n antaman matkan ja keston (TCX:ää käytettäessä). Vaatii
    [ilmaisen API-avaimen](https://digitransit.fi/en/developers/api-registration/).
 
 ### Valinnat
 
-| Lippu                | Kuvaus                                                                 |
-| -------------------- | ---------------------------------------------------------------------- |
-| `--output-dir DIR`   | Hakemisto, johon tiedostot kirjoitetaan (oletus: `./tcx_output`)       |
-| `--format FMT`       | Tiedostomuoto: `tcx` (oletus) tai `gpx`.                                 |
-| `--linear`           | Käytä suoraa viivaa asemien välillä                                    |
-| `--use-route`        | Käytä HSL:n ehdottamaa pyöräilyreittiä suoran viivan sijaan            |
+| Lippu                | Kuvaus                                                                         |
+| -------------------- | ------------------------------------------------------------------------------ |
+| `--output-dir DIR`   | Hakemisto, johon tiedostot kirjoitetaan (oletus: `./tcx_output`)               |
+| `--format FMT`       | Tiedostomuoto: `tcx` (oletus) tai `gpx`.                                       |
+| `--linear`           | Käytä suoraa viivaa asemien välillä                                            |
+| `--use-route`        | Käytä HSL:n ehdottamaa pyöräilyreittiä suoran viivan sijaan                    |
 | `--api-key KEY`      | Digitransit API -avain (vaihtoehto `DIGITRANSIT_API_KEY`-ympäristömuuttujalle) |
-| `--refresh-stations` | Pakota pyöräasemien koordinaattilistan uudelleenlataus                 |
-| `-v`, `--verbose`    | Ota käyttöön laajennettu/debug-lokitus                                 |
+| `--refresh-stations` | Pakota pyöräasemien koordinaattilistan uudelleenlataus                         |
+| `-v`, `--verbose`    | Ota käyttöön laajennettu/debug-lokitus                                         |
 
 ### TCX vs GPX
 
 Vaikka GPX on yleisin tiedostomuoto, se ei tue ajetun kokonaismatkan antamista. Strava laskee matkan annettujen
 GPS-pisteiden perusteella.
 
-**TCX** on suositellumpi tiedostomuoto, koska sen avulla kaupunkipyörän antama etäisyyslukema pysyy tiedostossa GPS-reitistä riippumatta.
+**TCX** on suositellumpi tiedostomuoto, koska sen avulla kaupunkipyörän antama etäisyyslukema pysyy tiedostossa
+GPS-reitistä riippumatta.
 
 ```bash
 # Tuota TCX-tiedosto suoralla viivalla asemien välillä
@@ -72,7 +74,8 @@ uvx hsl-kaupunkipyora-exporter rides.txt --format tcx --linear
 
 Käyttääksesi HSL:n ehdottamaa todellista pyöräilyreittiä tarvitset Digitransit API -avaimen:
 
-1. Rekisteröidy ilmaiseksi osoitteessa [Digitransit Developer Portal](https://digitransit.fi/en/developers/api-registration/).
+1. Rekisteröidy ilmaiseksi osoitteessa
+   [Digitransit Developer Portal](https://digitransit.fi/en/developers/api-registration/).
 1. Anna avain `--api-key`-lipulla tai `DIGITRANSIT_API_KEY`-ympäristömuuttujalla.
 
 ```bash

--- a/README.fi.md
+++ b/README.fi.md
@@ -1,0 +1,118 @@
+# HSL Kaupunkipyörä Exporter
+
+[![en](https://img.shields.io/badge/lang-en-red.svg)](./README.md)
+[![fi](https://img.shields.io/badge/lang-fi-blue.svg)](./README.fi.md)
+[![sv](https://img.shields.io/badge/lang-sv-yellow.svg)](./README.sv.md)
+
+Jäsennä [HSL:n kaupunkipyörien](https://www.hsl.fi/omat-tiedot/kaupunkipyorat/ajohistoria) ajohistoriasi ja vie jokainen
+ajo Strava-yhteensopivana TCX- tai GPX-tiedostona.
+
+## Asennus
+
+Vaatii Python 3.13+. Helpoin tapa ajaa työkalu on [`uvx`](https://docs.astral.sh/uv/):llä:
+
+```bash
+uvx hsl-kaupunkipyora-exporter rides.txt
+```
+
+Tai asenna `pip`:llä:
+
+```bash
+pip install hsl-kaupunkipyora-exporter
+hsl-kaupunkipyora-exporter rides.txt
+```
+
+## Käyttö
+
+1. Avaa ajohistoriasi osoitteessa <https://www.hsl.fi/omat-tiedot/kaupunkipyorat/ajohistoria>.
+1. Tallenna sivu HTML-tiedostona (`Ctrl+S`) **tai** kopioi näkyvä teksti `.txt`-tiedostoon.
+1. Aja exporter:
+
+```bash
+uvx hsl-kaupunkipyora-exporter rides.html
+```
+
+### Reittitilat
+
+Exporter tukee kolmea eri tilaa maantieteellisen datan käsittelyyn:
+
+1. **Vain yhteenveto (oletus)**: Vie TCX-tiedoston, joka sisältää HSL:n ilmoittaman tarkan matkan ja keston, mutta ei
+   GPS-reittipisteitä. Tämä on tarkin tapa kirjata kilometrit Stravaan ilman reitin arvaamista.
+1. **Suora reitti (`--linear`)**: Sisältää yksinkertaisen kahden pisteen suoran viivan lähtö- ja palautusaseman välillä.
+   Hyödyllinen, jos haluat perusvisualisoinnin kartalle.
+1. **Reititetty polku (`--use-route`)**: Hakee ehdotetun pyöräilyreitin
+   [Digitransit-rajapinnasta](https://digitransit.fi/kehittajille/rajapinnat/). Tämä tarjoaa realistisen reitin kartalla
+   ja säilyttää HSL:n matkatiedot (TCX:ää käytettäessä). Vaatii
+   [ilmaisen API-avaimen](https://digitransit.fi/kehittajille/api-rekisteroityminen/).
+
+### Valinnat
+
+| Lippu                | Kuvaus                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| `--output-dir DIR`   | Hakemisto, johon tiedostot kirjoitetaan (oletus: `./tcx_output`)       |
+| `--format FMT`       | Vientimuoto: `tcx` (oletus) tai `gpx`.                                 |
+| `--linear`           | Sisällytä suora viiva asemien välillä                                  |
+| `--use-route`        | Käytä HSL:n ehdottamaa pyöräilyreittiä suoran viivan sijaan            |
+| `--api-key KEY`      | Digitransit API -avain (vaihtoehto `DIGITRANSIT_API_KEY`-ympäristömuuttujalle) |
+| `--refresh-stations` | Pakota pyöräasemien koordinaattilistan uudelleenlataus                 |
+| `-v`, `--verbose`    | Ota käyttöön laajennettu/debug-lokitus                                 |
+
+### TCX vs GPX
+
+Vaikka GPX on yleisin muoto, se ei tue eksplisiittistä "kokonaismatkan" ohitusta. Strava laskee matkan annettujen
+GPS-pisteiden perusteella.
+
+**TCX** on oletus- ja suositeltu muoto, koska sen avulla työkalu voi kertoa Stravalle tarkalleen, kuinka monta
+kilometriä ajo oli, GPS-reitistä riippumatta.
+
+```bash
+# Vie TCX-muotoon suoralla viivalla asemien välillä
+uvx hsl-kaupunkipyora-exporter rides.txt --linear
+```
+
+### Reititetyn polun asetus
+
+Käyttääksesi HSL:n ehdottamaa todellista pyöräilyreittiä tarvitset Digitransit API -avaimen:
+
+1. Rekisteröidy ilmaiseksi osoitteessa [Digitransit Developer Portal](https://digitransit.fi/kehittajille/api-rekisteroityminen/).
+1. Anna avain `--api-key`-lipulla tai `DIGITRANSIT_API_KEY`-ympäristömuuttujalla.
+
+```bash
+uvx hsl-kaupunkipyora-exporter rides.txt --use-route --api-key avaimesi_tahan
+```
+
+### Kilometrikisa
+
+Tämä on kätevä tapa lisätä **Alepa Fillari** -kilometrit [Kilometrikisaan](https://www.kilometrikisa.fi/) tuomalla ajot
+ensin Stravaan.
+
+## Miten se toimii
+
+```mermaid
+graph TD
+    A[HSL:n ajohistoria<br/>HTML tai teksti] --> B(RideHistoryParser)
+    B --> C{StationLookup}
+    C -- Koordinaatit löytyivät --> D{Reittitila?}
+    C -- Ei löydy --> E[Ohita ajo]
+
+    D -- Oletus --> F[Vain yhteenveto]
+    D -- "--linear" --> G[Suora reitti]
+    D -- "--use-route" --> H[fetch_route Digitransit-rajapinnalla]
+
+    F --> I(TCX/GPX-kirjoitin)
+    G --> I
+    H --> I
+
+    I --> J[Strava-yhteensopivat<br/>TCX- tai GPX-tiedostot]
+```
+
+## Kehitys
+
+Käytä [`just`](https://github.com/casey/just)-työkalua tehtävien ajamiseen.
+
+```bash
+git clone https://github.com/nikosavola/hsl-kaupunkipyora-exporter.git
+cd hsl-kaupunkipyora-exporter
+just install
+just test
+```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # HSL Kaupunkipyörä Exporter
 
+[![en](https://img.shields.io/badge/lang-en-red.svg)](./README.md)
+[![fi](https://img.shields.io/badge/lang-fi-blue.svg)](./README.fi.md)
+[![sv](https://img.shields.io/badge/lang-sv-yellow.svg)](./README.sv.md)
+
 Parse your [HSL City Bike](https://www.hsl.fi/en/my-information/citybikes/ride-history) ride history and export each
 ride as a Strava-compatible TCX or GPX file.
 

--- a/README.sv.md
+++ b/README.sv.md
@@ -1,0 +1,37 @@
+# HSL Kaupunkipyörä Exporter
+
+[![en](https://img.shields.io/badge/lang-en-red.svg)](./README.md)
+[![fi](https://img.shields.io/badge/lang-fi-blue.svg)](./README.fi.md)
+[![sv](https://img.shields.io/badge/lang-sv-yellow.svg)](./README.sv.md)
+
+Exportera din [HSL-stadscykel](https://www.hsl.fi/sv/mina-uppgifter/stadscyklar/resehistorik)-historik som
+Strava-kompatibla TCX- eller GPX-filer.
+
+> För fullständig dokumentation, se [engelska](./README.md) eller [finska](./README.fi.md) versionen.
+
+## Installation
+
+Kräver Python 3.13+.
+
+```bash
+uvx hsl-kaupunkipyora-exporter rides.txt
+```
+
+## Användning
+
+1. Öppna din resehistorik på <https://www.hsl.fi/sv/mina-uppgifter/stadscyklar/resehistorik>.
+1. Spara sidan som HTML (`Ctrl+S`) eller kopiera texten till en `.txt`-fil.
+1. Kör verktyget:
+
+```bash
+uvx hsl-kaupunkipyora-exporter rides.html
+```
+
+## Banlägen
+
+- **Standard**: Endast sammanfattning (exakt sträcka och tid från HSL, inga GPS-punkter).
+- `--linear`: Rak linje mellan stationerna.
+- `--use-route`: Riktig cykelrutt via [Digitransit API](https://digitransit.fi/sv/utvecklare/apier/) (kräver en gratis
+  API-nyckel).
+
+**TCX** är standardformatet eftersom det låter Strava använda HSL:s exakta sträcka. GPX stöder inte detta.

--- a/README.sv.md
+++ b/README.sv.md
@@ -4,14 +4,14 @@
 [![fi](https://img.shields.io/badge/lang-fi-blue.svg)](./README.fi.md)
 [![sv](https://img.shields.io/badge/lang-sv-yellow.svg)](./README.sv.md)
 
-Exportera din [HSL-stadscykel](https://www.hsl.fi/sv/mina-uppgifter/stadscyklar/resehistorik)-historik som
+Exportera din [HRT-stadscykel](https://www.hsl.fi/sv/mina-uppgifter/stadscyklar/rental-history)-historik som
 Strava-kompatibla TCX- eller GPX-filer.
 
-> För fullständig dokumentation, se [engelska](./README.md) eller [finska](./README.fi.md) versionen.
+> För fullständig dokumentation, se den [engelska](./README.md) eller den [finska](./README.fi.md) versionen.
 
 ## Installation
 
-Kräver Python 3.13+.
+Kräver Python 3.13+. Det är enklast att köra verktyget med [`uvx`](https://docs.astral.sh/uv/)::
 
 ```bash
 uvx hsl-kaupunkipyora-exporter rides.txt
@@ -19,19 +19,19 @@ uvx hsl-kaupunkipyora-exporter rides.txt
 
 ## Användning
 
-1. Öppna din resehistorik på <https://www.hsl.fi/sv/mina-uppgifter/stadscyklar/resehistorik>.
-1. Spara sidan som HTML (`Ctrl+S`) eller kopiera texten till en `.txt`-fil.
+1. Öppna din resehistorik på <https://www.hsl.fi/sv/mina-uppgifter/stadscyklar/rental-history>.
+1. Spara sajten som HTML (`Ctrl+S`) eller kopiera resehistoriktexten till en `.txt`-fil.
 1. Kör verktyget:
 
 ```bash
 uvx hsl-kaupunkipyora-exporter rides.html
 ```
 
-## Banlägen
+## Reititystavat
 
-- **Standard**: Endast sammanfattning (exakt sträcka och tid från HSL, inga GPS-punkter).
+- **Standard**: Endast sträcka och tid från HRT, inga GPS-punkter.
 - `--linear`: Rak linje mellan stationerna.
-- `--use-route`: Riktig cykelrutt via [Digitransit API](https://digitransit.fi/sv/utvecklare/apier/) (kräver en gratis
+- `--use-route`: Riktig cykelrutt via [Digitransit API](https://digitransit.fi/en/developers/apis/) (kräver en gratis
   API-nyckel).
 
 **TCX** är standardformatet eftersom det låter Strava använda HSL:s exakta sträcka. GPX stöder inte detta.


### PR DESCRIPTION
Follows the multilanguage-readme-pattern with language shields at the
top of each file. The Finnish version mirrors the English content; the
Swedish version is intentionally concise to ease maintenance.